### PR TITLE
Fix incorrect dynamic variable y showing as x

### DIFF
--- a/src/main/java/net/jsa2025/calcmod/commands/CalcCommand.java
+++ b/src/main/java/net/jsa2025/calcmod/commands/CalcCommand.java
@@ -116,7 +116,7 @@ public class CalcCommand {
         vars.put("hour", 3600.0);
         if (Objects.nonNull(player)) {
             vars.put("x", (double) player.getBlockPos().getX());
-            vars.put("y", (double) player.getBlockPos().getX());
+            vars.put("y", (double) player.getBlockPos().getY());
             vars.put("z", (double) player.getBlockPos().getZ());
             vars.put("health", (double) ((PlayerEntity) player).getHealth());
         }


### PR DESCRIPTION
This PR fixes an issue where the dynamic variable y was incorrectly displaying the player's x coordinate instead of the correct y coordinate.